### PR TITLE
Adding even more specific overrides.

### DIFF
--- a/templates/edit-button.html.twig
+++ b/templates/edit-button.html.twig
@@ -61,13 +61,16 @@
     width: 28%;
     padding: 0;
     margin: 0;
+    font-size: 12px;
+    line-height: 20px;
 }
 #bolt-edit-info dd {
     float: left;
     width: 72%;
     padding: 0;
     margin: 0;
-}
+    font-size: 12px;
+    line-height: 20px;
 }
 
 #bolt-edit-this.position-top-left {


### PR DESCRIPTION
… to fix this: 

![Schermafbeelding 2022-10-05 om 11 24 50](https://user-images.githubusercontent.com/1833361/194027506-c17023a8-2dfb-4335-ab83-d1ba30512ab6.png)

(and I've also removed a rogue `}`)
